### PR TITLE
Replace moq with nsubstitute

### DIFF
--- a/src/UnitTests/RxTelegram.Bot.UnitTests.csproj
+++ b/src/UnitTests/RxTelegram.Bot.UnitTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="nunit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />


### PR DESCRIPTION
We dont want to use moq anymore, because of serious privacy concern and lost of trust.

See: https://github.com/moq/moq/issues/1372
