### PR TITLE
Fix return type of ITelegramBot.ForwardMessages

### DIFF
--- a/src/RxTelegram.Bot/ITelegramBot.cs
+++ b/src/RxTelegram.Bot/ITelegramBot.cs
@@ -1132,7 +1132,7 @@ public interface ITelegramBot
     /// <param name="forwardMessages">MessageIds to forward</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns>Returns True on success.</returns>
-    Task<bool> ForwardMessages(ForwardMessages forwardMessages, CancellationToken cancellationToken = default);
+    Task<MessageIdObject[]> ForwardMessages(ForwardMessages forwardMessages, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat.

--- a/src/RxTelegram.Bot/TelegramBot.cs
+++ b/src/RxTelegram.Bot/TelegramBot.cs
@@ -1284,8 +1284,8 @@ public class TelegramBot : BaseTelegramBot, ITelegramBot
     /// <param name="forwardMessages">MessageIds to forward</param>
     /// <param name="cancellationToken">Propagates notification that operations should be canceled.</param>
     /// <returns>Returns True on success.</returns>
-    public Task<bool> ForwardMessages(ForwardMessages forwardMessages, CancellationToken cancellationToken = default) =>
-        Post<bool>("forwardMessages", forwardMessages, cancellationToken);
+    public Task<MessageIdObject[]> ForwardMessages(ForwardMessages forwardMessages, CancellationToken cancellationToken = default) =>
+        Post<MessageIdObject[]>("forwardMessages", forwardMessages, cancellationToken);
 
     /// <summary>
     /// Use this method to get the list of boosts added to a chat by a user. Requires administrator rights in the chat.


### PR DESCRIPTION
As I mentioned in [this discussion]( https://github.com/RxTelegram/RxTelegram.Bot/discussions/40) the return type of `TelegramBot.ForwardMessages` in the library is `Task<bool>`. While in the [Telegram Bot API documentation](https://core.telegram.org/bots/api#forwardmessages) there is written that `forwardMessages` return `MessageId`'s array. 
