### PR TITLE
Fix: add update tracking for specific update types

### DIFF
--- a/src/RxTelegram.Bot/Api/IUpdateManager.cs
+++ b/src/RxTelegram.Bot/Api/IUpdateManager.cs
@@ -3,6 +3,8 @@ using RxTelegram.Bot.Interface.BaseTypes;
 using RxTelegram.Bot.Interface.InlineMode;
 using RxTelegram.Bot.Interface.Payments;
 using RxTelegram.Bot.Interface.Setup;
+using RxTelegram.Bot.Interface.Reaction;
+
 
 #if NETSTANDARD2_1
 using System.Collections.Generic;
@@ -100,6 +102,20 @@ public interface IUpdateManager
     /// </summary>
     IObservable<ChatBoostRemoved> RemovedChatBoost { get; }
 
+    /// <summary>
+    /// A reaction to a message was changed by a user.
+    /// The bot must be an administrator in the chat and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates.
+    /// The update isn't received for reactions set by bots.
+    /// </summary>
+    IObservable<MessageReactionUpdated> MessageReaction { get; }
+
+    /// <summary>
+    /// Reactions to a message with anonymous reactions were changed.
+    /// The bot must be an administrator in the chat and must explicitly specify "message_reaction_count" in the list of allowed_updates to receive these updates.
+    /// The updates are grouped and can be sent with delay up to a few minutes.
+    /// </summary>
+    IObservable<MessageReactionCountUpdated> MessageReactionCount { get; }
+
 #if NETSTANDARD2_1
     /// <summary>
     /// Updates of all Types.
@@ -189,5 +205,19 @@ public interface IUpdateManager
     /// A boost was removed from a chat. The bot must be an administrator in the chat to receive these updates.
     /// </summary>
     IAsyncEnumerable<ChatBoostRemoved> RemovedChatBoostEnumerable();
+
+    /// <summary>
+    /// A reaction to a message was changed by a user.
+    /// The bot must be an administrator in the chat and must explicitly specify "message_reaction" in the list of allowed_updates to receive these updates.
+    /// The update isn't received for reactions set by bots.
+    /// </summary>
+    IAsyncEnumerable<MessageReactionUpdated> MessageReactionEnumerable();
+
+    /// <summary>
+    /// Reactions to a message with anonymous reactions were changed.
+    /// The bot must be an administrator in the chat and must explicitly specify "message_reaction_count" in the list of allowed_updates to receive these updates.
+    /// The updates are grouped and can be sent with delay up to a few minutes.
+    /// </summary>
+    IAsyncEnumerable<MessageReactionCountUpdated> MessageReactionCountEnumerable();
 #endif
 }

--- a/src/RxTelegram.Bot/Api/UpdateManager.cs
+++ b/src/RxTelegram.Bot/Api/UpdateManager.cs
@@ -7,6 +7,7 @@ using RxTelegram.Bot.Interface.BaseTypes;
 using RxTelegram.Bot.Interface.BaseTypes.Enums;
 using RxTelegram.Bot.Interface.InlineMode;
 using RxTelegram.Bot.Interface.Payments;
+using RxTelegram.Bot.Interface.Reaction;
 using RxTelegram.Bot.Interface.Setup;
 #if NETSTANDARD2_1
 using RxTelegram.Bot.Utils;
@@ -50,6 +51,10 @@ public class UpdateManager : IUpdateManager
 
     public IObservable<ChatBoostRemoved> RemovedChatBoost => _chatBoostRemoved;
 
+    public IObservable<MessageReactionUpdated> MessageReaction => _messageReaction;
+
+    public IObservable<MessageReactionCountUpdated> MessageReactionCount => _messageReactionCount;
+
 
     private readonly IDictionary<UpdateTypeWrapper<UpdateType?>, List<object>> _observerDictionary;
     private readonly Observable<Update> _update;
@@ -69,6 +74,8 @@ public class UpdateManager : IUpdateManager
     private readonly Observable<ChatJoinRequest> _chatJoinRequest;
     private readonly Observable<ChatBoostUpdated> _chatBoostUpdated;
     private readonly Observable<ChatBoostRemoved> _chatBoostRemoved;
+    private readonly Observable<MessageReactionUpdated> _messageReaction;
+    private readonly Observable<MessageReactionCountUpdated> _messageReactionCount;
 
     private readonly ITelegramBot _telegramBot;
     private const int NotRunning = 0;
@@ -106,6 +113,8 @@ public class UpdateManager : IUpdateManager
         _inlineQuery = new Observable<InlineQuery>(UpdateType.InlineQuery, this);
         _editedMessage = new Observable<Message>(UpdateType.EditedMessage, this);
         _message = new Observable<Message>(UpdateType.Message, this);
+        _messageReaction = new Observable<MessageReactionUpdated>(UpdateType.MessageReaction, this);
+        _messageReactionCount = new Observable<MessageReactionCountUpdated>(UpdateType.MessageReactionCount, this);
         _update = new Observable<Update>(null, this);
     }
 
@@ -198,6 +207,13 @@ public class UpdateManager : IUpdateManager
                                    update => OnNext(UpdateType.InlineQuery, update.InlineQuery),
                                    update => OnNext(UpdateType.EditedMessage, update.EditedMessage),
                                    update => OnNext(UpdateType.Message, update.Message),
+                                   update => OnNext(UpdateType.MessageReaction, update.MessageReaction),
+                                   update => OnNext(UpdateType.MessageReactionCount, update.MessageReactionCount),
+                                   update => OnNext(UpdateType.MyChatMember, update.MyChatMember),
+                                   update => OnNext(UpdateType.ChatMember, update.ChatMember),
+                                   update => OnNext(UpdateType.ChatJoinRequest, update.ChatJoinRequest),
+                                   update => OnNext(UpdateType.ChatBoost, update.ChatBoost),
+                                   update => OnNext(UpdateType.RemovedChatBoost, update.RemovedChatBoost),
                                };
 
         foreach (var update in updates)
@@ -399,6 +415,10 @@ public class UpdateManager : IUpdateManager
     public IAsyncEnumerable<ChatBoostUpdated> ChatBoostEnumerable() => _chatBoostUpdated.ToAsyncEnumerable();
 
     public IAsyncEnumerable<ChatBoostRemoved> RemovedChatBoostEnumerable() => _chatBoostRemoved.ToAsyncEnumerable();
+
+    public IAsyncEnumerable<MessageReactionUpdated> MessageReactionEnumerable() => _messageReaction.ToAsyncEnumerable();
+
+    public IAsyncEnumerable<MessageReactionCountUpdated> MessageReactionCountEnumerable() => _messageReactionCount.ToAsyncEnumerable();
 #endif
 
     private struct UpdateTypeWrapper<T>

--- a/src/RxTelegram.Bot/Interface/BaseTypes/Enums/UpdateType.cs
+++ b/src/RxTelegram.Bot/Interface/BaseTypes/Enums/UpdateType.cs
@@ -16,6 +16,10 @@ public enum UpdateType
 
     EditedChannelPost,
 
+    MessageReaction,
+
+    MessageReactionCount,
+
     ShippingQuery,
 
     PreCheckoutQuery,

--- a/src/UnitTests/UpdateManagerTest.cs
+++ b/src/UnitTests/UpdateManagerTest.cs
@@ -10,6 +10,7 @@ using RxTelegram.Bot.Interface.BaseTypes;
 using RxTelegram.Bot.Interface.BaseTypes.Enums;
 using RxTelegram.Bot.Interface.InlineMode;
 using RxTelegram.Bot.Interface.Payments;
+using RxTelegram.Bot.Interface.Reaction;
 using RxTelegram.Bot.Interface.Setup;
 
 namespace RxTelegram.Bot.UnitTests;
@@ -387,6 +388,75 @@ public class UpdateManagerTest
                                   .PollAnswer);
         disposableAll.Dispose();
     }
+
+    private void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers<T>(
+        Update update,
+        Func<UpdateManager,IObservable<T>> observable,
+        Func<Update, T> selector)
+    {
+        // Arrange
+        var observer = Substitute.For<IObserver<T>>();
+        var updateManager = new UpdateManager(_telegramBotMock);
+        var disposableAll = observable(updateManager).Subscribe(observer);
+        Update[] updates = [update];
+
+        // Act
+        updateManager.DistributeUpdates(updates);
+
+        // Assert
+        observer.Received()
+                   .OnNext(selector(updates.Single()));
+        disposableAll.Dispose();
+    }
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_ChatMemberObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { ChatMember = new ChatMemberUpdated() },
+            (UpdateManager updateManager) => updateManager.ChatMember,
+            (Update update) => update.ChatMember);
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_MyChatMemberObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { MyChatMember = new ChatMemberUpdated() },
+            (UpdateManager updateManager) => updateManager.MyChatMember,
+            (Update update) => update.MyChatMember);
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_ChatJoinRequestObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { ChatJoinRequest = new ChatJoinRequest() },
+            (UpdateManager updateManager) => updateManager.ChatJoinRequest,
+            (Update update) => update.ChatJoinRequest);
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_ChatBoostObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { ChatBoost = new ChatBoostUpdated() },
+            (UpdateManager updateManager) => updateManager.ChatBoost,
+            (Update update) => update.ChatBoost);
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_RemovedChatBoostObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { RemovedChatBoost = new ChatBoostRemoved() },
+            (UpdateManager updateManager) => updateManager.RemovedChatBoost,
+            (Update update) => update.RemovedChatBoost);
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_MessageReactionObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { MessageReaction = new MessageReactionUpdated() },
+            (UpdateManager updateManager) => updateManager.MessageReaction,
+            (Update update) => update.MessageReaction);
+
+    [Test]
+    public void Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_MessageReactionCountObservers()
+        => Given_ValidUpdate_On_DistributeUpdates_Should_PushUpdatesTo_Observers(
+            new Update { MessageReactionCount = new MessageReactionCountUpdated() },
+            (UpdateManager updateManager) => updateManager.MessageReactionCount,
+            (Update update) => update.MessageReactionCount);
 
     #endregion
 }


### PR DESCRIPTION
- Added `UpdateType.MessageReaction` and `UpdateType.MessageReactionCount`
- Extended `IUpdateManager` with:
  - `MessageReaction`
  - `MessageReactionCount`
  - `MessageReactionEnumerable()`
  - `MessageReactionCountEnumerable()`
- Implemented the above members in `UpdateManager : IUpdateManager`
- Fixed missing tracking in `UpdateManager` for:
  - `MessageReaction`
  - `MessageReactionCount`
  - `MyChatMember`
  - `ChatMember`
  - `ChatJoinRequest`
  - `ChatBoost`
  - `RemovedChatBoost`
- Added unit tests

Fixes #69
Fixes #77