### PR TITLE
feat(keyboard): extend IInlineKeyboardRow with builder methods + serialization fixes

### DIFF
--- a/src/RxTelegram.Bot/Interface/BaseTypes/InlineKeyboardButton.cs
+++ b/src/RxTelegram.Bot/Interface/BaseTypes/InlineKeyboardButton.cs
@@ -60,7 +60,7 @@ public class InlineKeyboardButton
     /// <summary>
     /// Optional. Description of the button that copies the specified text to the clipboard.
     /// </summary>
-    public CopyTextButton CopyTextButton { get; set; }
+    public CopyTextButton CopyText { get; set; }
 
     /// <summary>
     /// Optional. Description of the game that will be launched when the user presses the button.
@@ -72,5 +72,5 @@ public class InlineKeyboardButton
     /// Optional. Specify True, to send a Pay button.
     /// NOTE: This type of button must always be the first button in the first row.
     /// </summary>
-    public bool Pay { get; set; }
+    public bool? Pay { get; set; }
 }

--- a/src/RxTelegram.Bot/Utils/Keyboard/Interfaces/IInlineKeyboardRow.cs
+++ b/src/RxTelegram.Bot/Utils/Keyboard/Interfaces/IInlineKeyboardRow.cs
@@ -4,6 +4,8 @@ namespace RxTelegram.Bot.Utils.Keyboard.Interfaces;
 
 public interface IInlineKeyboardRow
 {
+    public IInlineKeyboardRow AddButton(InlineKeyboardButton button);
+
     public IInlineKeyboardRow AddUrl(string text, string url);
 
     public IInlineKeyboardRow AddLoginUrl(string text, LoginUrl loginUrl);
@@ -13,6 +15,8 @@ public interface IInlineKeyboardRow
     public IInlineKeyboardRow AddCallbackData(string text, string callbackData);
 
     public IInlineKeyboardRow AddCallbackGame(string text);
+
+    public IInlineKeyboardRow AddCopyText(string text, string copyText);
 
     public IInlineKeyboardRow AddSwitchInlineQuery(string text, string switchInlineQuery);
 

--- a/src/RxTelegram.Bot/Utils/Keyboard/KeyboardBuilder.cs
+++ b/src/RxTelegram.Bot/Utils/Keyboard/KeyboardBuilder.cs
@@ -142,7 +142,7 @@ public class KeyboardBuilder : IReplyKeyboardRow, IReplyKeyboardBuilder, IInline
         _inlineRow.Add(new InlineKeyboardButton
                        {
                            Text = text,
-                           CopyTextButton = new CopyTextButton()
+                           CopyText = new CopyTextButton()
                            {
                                 Text = copyText
                            }

--- a/src/RxTelegram.Bot/Utils/Keyboard/KeyboardBuilder.cs
+++ b/src/RxTelegram.Bot/Utils/Keyboard/KeyboardBuilder.cs
@@ -137,6 +137,25 @@ public class KeyboardBuilder : IReplyKeyboardRow, IReplyKeyboardBuilder, IInline
         return this;
     }
 
+    public IInlineKeyboardRow AddCopyText(string text, string copyText)
+    {
+        _inlineRow.Add(new InlineKeyboardButton
+                       {
+                           Text = text,
+                           CopyTextButton = new CopyTextButton()
+                           {
+                                Text = copyText
+                           }
+                       });
+        return this;
+    }
+
+    public IInlineKeyboardRow AddButton(InlineKeyboardButton button)
+    {
+        _inlineRow.Add(button);
+        return this;
+    }
+
     public IInlineKeyboardRow AddSwitchInlineQuery(string text, string switchInlineQuery)
     {
         _inlineRow.Add(new InlineKeyboardButton { Text = text, SwitchInlineQuery = switchInlineQuery });


### PR DESCRIPTION
## New Features & Improvements
### 1. Keyboard Builder Enhancements
- Extended `IInlineKeyboardRow` interface with:
  - `AddButton()`: Explicitly constructs custom buttons with complex behavior
  - `AddCopyText()`: Factory method for pre-configured copy-text buttons (auto-populates API-compliant payloads)

### 2. Serialization Fixes
- Changed `InlineKeyboardButton.Pay` property to nullable (`bool?`)  
  - Prevents serialization conflicts with other button types
- Renamed `InlineKeyboardButton.CopyTextButton` property → `CopyText`  
  - Aligns with official Telegram Bot API naming
  - Fixes payload serialization issues

## Impact
- Simplifies inline keyboard construction  
- Ensures compliance with Telegram API specs  
- Resolves serialization edge cases  